### PR TITLE
fix(#26): another small fix

### DIFF
--- a/internal/repository/downstreams/attendeeservice/client.go
+++ b/internal/repository/downstreams/attendeeservice/client.go
@@ -65,5 +65,9 @@ func (i *Impl) ListMyRegistrationIds(ctx context.Context) ([]int64, error) {
 		Body: &bodyDto,
 	}
 	err := i.listMyRegistrationsClient.Perform(ctx, http.MethodGet, url, nil, &response)
+	if response.Status == http.StatusNotFound {
+		// not really an error - this user has no registrations
+		return make([]int64, 0), nil
+	}
 	return bodyDto.Ids, downstreams.ErrByStatus(err, response.Status)
 }


### PR DESCRIPTION
right now, if a user requests transactions but has no registrations, the attendee service returns 404, which causes the payment service to return 500.

But this is a valid situation, and the correct response is 403.